### PR TITLE
This fixes the issue of the hint not showing only on galaxy s5 devices

### DIFF
--- a/library/src/com/wrapp/floatlabelededittext/FloatLabeledEditText.java
+++ b/library/src/com/wrapp/floatlabelededittext/FloatLabeledEditText.java
@@ -119,7 +119,6 @@ public class FloatLabeledEditText extends FrameLayout {
 
             @Override
             public void afterTextChanged(Editable s) {
-                setShowHint(!TextUtils.isEmpty(s));
             }
 
             @Override
@@ -128,6 +127,15 @@ public class FloatLabeledEditText extends FrameLayout {
 
             @Override
             public void onTextChanged(CharSequence s, int start, int before, int count) {
+                if (s.length() == 0) {
+                    if (before == 1) {
+                        setShowHint(false);
+                    } else if (before > 1) {
+                        setShowHint(true);
+                    }
+                } else {
+                    setShowHint(!TextUtils.isEmpty(s));
+                }
             }
 
         });


### PR DESCRIPTION
With this fix, the hint shows up and disappears as the text is deleted on any device including galaxy s5.
